### PR TITLE
Update readme api install and rubric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ What's Cookin' Good Lookin' is an application that presents a user with an exten
 ![deleting-favs](https://github.com/janitastic/whats-cookin-good-lookin/blob/main/github/Deleting-Favorites.gif)
 
 ## Installation and Setup:
-**To navigate the website live, a server download is required.**
-  1. Download the necessary server and API [here](https://github.com/turingschool-examples/whats-cookin-starter-kit)
-  2. In the command line, run `npm install` or `npm i`.
-  3. In the command line, run `npm start`
+**To navigate the website live, a local server download is required.**
+  1. Clone the necessary server and API [here](https://github.com/turingschool-examples/whats-cookin-api)
+  2. In the command line, `cd` into the directory and run `npm install` or `npm i`.
+  3. After the install is completely, run `npm start`.
 
 **Then clone down this repository**
   1. In your command line, `cd` into your local directory and clone down this repository -<br>
@@ -53,5 +53,6 @@ What's Cookin' Good Lookin' is an application that presents a user with an exten
 
 ## Rubric
   - Part One [Rubric and Project Specifications - Part 1](https://frontend.turing.edu/projects/whats-cookin-part-one.html)
+  - Part Two [Rubric and Project Specifications - Part 2](https://frontend.turing.edu/projects/whats-cookin-part-two.html) 
 
 


### PR DESCRIPTION
### Description

Updated our readme with the new local server clone instructions and added the part two spec to the rubric section.

### Select One Thing
- [x] This broke nothing
- [ ] This broke something
- [ ] This broke everything
- [ ] This fixed something

### Fixes (if any)
 - We didn't need the old starter pack API per Nik's feedback.
 - Updated the instructions to include cloning this repo - https://github.com/turingschool-examples/whats-cookin-api

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Next Steps:
 - Continue with setting up fetch calls to local server.
